### PR TITLE
fix(chungthuang): Optionally ask user if they want to prune volume

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-tilt up $@ && tilt down $@
+tilt up $@ && tilt down $@ && docker volume prune


### PR DESCRIPTION
With this PR `./run.sh` asks if you want to prune volume when you stops it
```
➜  platform__dev-env git:(main) ./run.sh strapi
Tilt started on http://localhost:10350/
v0.20.3, built 2021-05-14

(space) to open the browser
(s) to stream logs (--stream=true)
(t) to open legacy terminal mode (--legacy=true)
(ctrl-c) to exit
Opening browser: http://localhost:10350/
Beginning Tiltfile execution
Successfully loaded Tiltfile (2.554933039s)
Stopping platform__dev-env_strapi_1 ... 
Stopping platform__dev-env_db_1     ... 
Stopping platform__dev-env_strapi_1 ... done
Stopping platform__dev-env_db_1     ... done
Removing platform__dev-env_strapi_1 ... 
Removing platform__dev-env_db_1     ... 
Removing platform__dev-env_strapi_1 ... done
Removing platform__dev-env_db_1     ... done
Removing network platform__dev-env_default
WARNING! This will remove all local volumes not used by at least one container.
Are you sure you want to continue? [y/N] y
Deleted Volumes:
442f549395d0b3aea2f3be8b7c5014b48d43473f8929d059d7c34481cef2ec2f
1adc348adfd8a86d3b226e783507893b0bc00377fda90639efe3454d650d9ac1

Total reclaimed space: 425.9MB
```